### PR TITLE
Add support for Orange FunBox 3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -171,6 +171,7 @@ homeassistant/components/ohmconnect/* @robbiet480
 homeassistant/components/onboarding/* @home-assistant/core
 homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff
+homeassistant/components/orange_funbox/* @janekbaraniewski
 homeassistant/components/orangepi_gpio/* @pascallj
 homeassistant/components/owlet/* @oblogic7
 homeassistant/components/panel_custom/* @home-assistant/core

--- a/homeassistant/components/orange_funbox/__init__.py
+++ b/homeassistant/components/orange_funbox/__init__.py
@@ -1,0 +1,1 @@
+"""Support for Orange FunBox 3 routers."""

--- a/homeassistant/components/orange_funbox/device_tracker.py
+++ b/homeassistant/components/orange_funbox/device_tracker.py
@@ -1,0 +1,146 @@
+"""Support for Orange FunBox router."""
+from collections import namedtuple
+import logging
+from typing import Any, Dict, List, Optional
+
+import requests
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import (
+    HomeAssistantType,
+    ConfigType,
+)
+import homeassistant.util.dt as dt_util
+from homeassistant.components.device_tracker import (
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    DeviceScanner,
+)
+from homeassistant.const import CONF_HOST
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_EXCLUDE = 'exclude'
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_EXCLUDE, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+Device = namedtuple(
+    'Device',
+    [
+        'active',
+        'device_type',
+        'first_seen',
+        'ip',
+        'last_connection',
+        'last_update',
+        'mac',
+        'name',
+        'signal_noise_ratio',
+        'signal_strength',
+    ],
+)
+
+
+class FunboxDeviceScanner(DeviceScanner):
+    """Device tracker for Orange FunBox 3."""
+
+    def __init__(self, config: ConfigType) -> None:
+        """Init."""
+        self.last_results = []
+
+        self.host = config[CONF_HOST]
+        self.exclude = config[CONF_EXCLUDE]
+
+        _LOGGER.debug('Scanner initialized')
+
+    def scan_devices(self) -> List[str]:
+        """Update list of devices from FunBox API."""
+        self._update_info()
+        return [
+            device.mac
+            for device in self.last_results
+        ]
+
+    def get_device_name(self, device: str) -> Optional[str]:
+        """Return the name of the given device or None."""
+        result = next(
+            (
+                result for result in self.last_results
+                if result.mac == device
+            ),
+            None,
+        )
+        return result.name if result else None
+
+    def get_extra_attributes(self, device: str) -> Optional[Dict[str, Any]]:
+        """Return all the attributes of the given device."""
+        result = next(
+            (
+                result for result in self.last_results
+                if result.mac == device
+            ),
+            None,
+        )
+        return result._asdict() if result else None
+
+    def _update_info(self) -> bool:
+        """Request list of devices from FunBox API."""
+        _LOGGER.debug('Getting devices')
+
+        path = '/sysbus/Devices:get'
+        resp = requests.post('http://{0}{1}'.format(self.host, path))
+
+        devices_data = resp.json()['status']
+
+        new_results = []
+
+        for device_data in devices_data:
+            mac = device_data.get('PhysAddress', None)
+
+            if not mac or mac in self.exclude:
+                continue
+
+            active = device_data.get('Active', False)
+
+            if not active:
+                continue
+
+            name = device_data.get('Name')
+            ipv4 = device_data.get('IPAddress')
+            first_seen = device_data.get('FirstSeen')
+            last_connection = device_data.get('LastConnection')
+            last_update = dt_util.utcnow()
+            device_type = device_data.get('DeviceType')
+            signal_strength = device_data.get('SignalStrength')
+            signal_noise_ratio = device_data.get('SignalNoiseRatio')
+
+            new_results.append(Device(
+                active=active,
+                device_type=device_type,
+                first_seen=first_seen,
+                ip=ipv4,
+                last_connection=last_connection,
+                last_update=last_update,
+                mac=mac.upper(),
+                name=name,
+                signal_noise_ratio=signal_noise_ratio,
+                signal_strength=signal_strength,
+            ))
+
+        self.last_results = new_results
+
+        _LOGGER.debug('FunBox devices updated')
+        return True
+
+
+def get_scanner(
+        hass: HomeAssistantType, config: ConfigType) -> FunboxDeviceScanner:
+    """Build FunboxDeviceScanner."""
+    return FunboxDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/orange_funbox/manifest.json
+++ b/homeassistant/components/orange_funbox/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "orange_funbox",
+  "name": "Orange Funbox",
+  "documentation": "",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": [
+    "@janekbaraniewski"
+  ]
+}

--- a/tests/components/orange_funbox/__init__.py
+++ b/tests/components/orange_funbox/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for orange_funbox component."""

--- a/tests/components/orange_funbox/test_device_tracker.py
+++ b/tests/components/orange_funbox/test_device_tracker.py
@@ -1,0 +1,112 @@
+"""Tests for Orange Funbox 3 device tracker platform."""
+from datetime import datetime
+from unittest import mock
+
+import pytest
+import requests_mock
+
+from homeassistant.components.orange_funbox.device_tracker import (
+    FunboxDeviceScanner,
+)
+
+
+NETWORK_DEVICE_MAC = 'SO:ME:MA:C'
+
+
+@pytest.mark.usefixtures('mocked_api', 'utcnow')
+def test_scan_devices(tracker):
+    """Test scanning for active devices."""
+    addresses = tracker.scan_devices()
+
+    assert len(addresses) == 1
+    assert addresses[0] == NETWORK_DEVICE_MAC
+
+
+def test_get_device_name(tracker):
+    """Test get device name by MAC address."""
+    name = tracker.get_device_name(NETWORK_DEVICE_MAC)
+
+    assert name == 'NetworkDevice'
+
+
+def test_get_extra_attributes(tracker, utcnow):
+    """Test get device extra attributes."""
+    attributes = tracker.get_extra_attributes(NETWORK_DEVICE_MAC)
+    assert attributes == dict(
+        active=True,
+        device_type='TestDevice',
+        first_seen='2018-08-10T10:12:13Z',
+        ip='192.168.1.10',
+        last_connection='2019-01-10T10:12:13Z',
+        last_update=utcnow,
+        mac=NETWORK_DEVICE_MAC,
+        name='NetworkDevice',
+        signal_noise_ratio=15,
+        signal_strength=-30,
+    )
+
+
+@pytest.fixture
+def mocked_api(response):
+    """Create mocked router API."""
+    with requests_mock.Mocker() as m:
+        m.post(
+            'http://foo.bar/sysbus/Devices:get',
+            json=response,
+            status_code=200,
+        )
+        yield m
+
+
+@pytest.fixture(scope='session')
+def utcnow(request):
+    """Freeze time at now()."""
+    start_dt = datetime.utcnow()
+    with mock.patch('homeassistant.util.dt.utcnow') as dt_utcnow:
+        dt_utcnow.return_value = start_dt
+        yield start_dt
+
+
+@pytest.fixture
+def response():
+    """Test router response."""
+    return {
+        'status': [
+            {
+                'PhysAddress': NETWORK_DEVICE_MAC,
+                'Name': 'NetworkDevice',
+                'IPAddress': '192.168.1.10',
+                'FirstSeen': '2018-08-10T10:12:13Z',
+                'LastConnection': '2019-01-10T10:12:13Z',
+                'DeviceType': 'TestDevice',
+                'SignalStrength': -30,
+                'SignalNoiseRatio': 15,
+                'Active': True,
+            },
+            {
+                'PhysAddress': 'SO:ME:MA:C2',
+                'Name': 'NotActiveDevice',
+                'Active': False,
+            },
+            {
+                'PhysAddress': None,
+                'Name': 'USBDevice',
+                'Active': True,
+            },
+        ]
+    }
+
+
+@pytest.fixture(scope='session')
+def tracker(config):
+    """Build FunboxDeviceScanner."""
+    return FunboxDeviceScanner(config)
+
+
+@pytest.fixture(scope='session')
+def config():
+    """Test tracker config."""
+    return {
+        'host': 'foo.bar',
+        'exclude': [],
+    }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
